### PR TITLE
Normalise metric names from common standard

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,4 +6,10 @@
 
 {shell, [{config, "config/dev.conf"}]}.
 
+{profiles, [
+           {test, [
+                   {erl_opts, [nowarn_export_all]}
+                  ]}
+          ]}.
+
 % vi: ft=erlang syn=erlang

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,9 @@
 {erl_opts, [debug_info]}.
 {deps, [{opencensus, "~> 0.6.0"}]}.
 
+{project_plugins, [rebar3_lint,
+                   covertool]}.
+
 {shell, [{config, "config/dev.conf"}]}.
 
 % vi: ft=erlang syn=erlang

--- a/src/opencensus_influxdb.erl
+++ b/src/opencensus_influxdb.erl
@@ -28,7 +28,7 @@ build_tags(Tags) ->
     lists:join($,, List).
 
 normalise(Atom) when is_atom(Atom) ->
-    normalise(erlang:atom_to_binary(Atom, utf8), <<>>);
+    normalise(erlang:atom_to_list(Atom, utf8), <<>>);
 normalise(String) when is_list(String) ->
     normalise(erlang:list_to_binary(String), <<>>);
 normalise(String) when is_binary(String) -> normalise(String, <<>>).
@@ -38,6 +38,7 @@ normalise(<<",", Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, "\\,
 normalise(<<" ", Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, "\\ ">>);
 normalise(<<"=", Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, "\\=">>);
 normalise(<<"\"", Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, "\\\"">>);
+normalise(<<"/", Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, "_">>);
 normalise(<<C, Rest/binary>>, Result) -> normalise(Rest, <<Result/binary, C>>).
 
 values(sum, #{count := Count,

--- a/test/opencensus_influxdb_SUITE.erl
+++ b/test/opencensus_influxdb_SUITE.erl
@@ -1,0 +1,36 @@
+-module(opencensus_influxdb_SUITE).
+
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [
+     metrics_has_normalised_names
+    ].
+
+metrics_has_normalised_names(_Config) ->
+    Metric = #{
+      name => "com.influxdata/example/metric",
+      ctags => #{},
+      tags => [],
+      data => #{
+        type => counter,
+        rows => [
+                 #{tags => [],
+                   value => 10}
+                ]
+       }
+     },
+    Output = build_output(Metric),
+    ct:pal("~s", [Output]),
+    ?assertEqual(nomatch, binary:match(Output, <<"/">>)),
+    ?assertNotMatch(nomatch, binary:match(Output, <<"value=10">>)),
+    ?assertMatch(<<"com.influxdata_example_metric", Rest/binary>>, Output),
+    ok.
+
+build_output(Metric) ->
+    IoList = opencensus_influxdb:build_metrics(Metric),
+
+    iolist_to_binary(IoList).


### PR DESCRIPTION
This allows users to define metrics in exporter independent way and then
let exporter handle the unification of the metric name to the exporter
requested format.